### PR TITLE
Nested params are masked.

### DIFF
--- a/src/ParamsFilter.php
+++ b/src/ParamsFilter.php
@@ -27,8 +27,13 @@ class ParamsFilter extends BaseObject
 
         $this->paramsFilter = function ($notice) {
             foreach ($this->params as $param) {
-                if (isset($notice['params'][$param])) {
-                    $notice['params'][$param] = $this->replacement;
+                $paramsToReplace = $this->explodeParams($param);
+
+                if ((count($paramsToReplace) === 1) && isset($notice['params'][$paramsToReplace[0]])) {
+                    $notice['params'][$paramsToReplace[0]] = $this->replacement;
+                }
+                if ((count($paramsToReplace) === 2) && isset($notice['params'][$paramsToReplace[0]][$paramsToReplace[1]])) {
+                    $notice['params'][$paramsToReplace[0]][$paramsToReplace[1]] = $this->replacement;
                 }
             }
             return $notice;
@@ -43,6 +48,22 @@ class ParamsFilter extends BaseObject
     public function getParamsFilter()
     {
         return $this->paramsFilter;
+    }
+
+    /**
+     * @param string $param
+     * @return string[]
+     */
+    private function explodeParams(string $param): array
+    {
+        $superglobals = ['_GET.', '_POST.', '_COOKIE.', '_SERVER.', '_ENV.', '_FILES.'];
+        foreach ($superglobals as $superglobal) {
+            if (strpos($param, $superglobal) === 0) {
+                $param = str_replace($superglobal, "", $param);
+                return explode(".", $param);
+            }
+        }
+        return [$param];
     }
 
 }


### PR DESCRIPTION
Nested parameters to be sent to Airbrake are now masked.

For example: `_POST.Login.Password` will now work, whereas before only non nested params, such as `_csrf`, would work.

* PHP superglobals are ignored, for example: `_POST.x.x` would be equal to `x.x`.
* This works only up to 2 nest levels, for example: `x.x` (or `_POST.x.x` for that matter) would be 2 nest levels, `x` would be 1. But `x.x.x` has 3 levels, so it won't work.