### PR TITLE
Added support for PHP 8.2

### DIFF
--- a/src/AirbrakeTarget.php
+++ b/src/AirbrakeTarget.php
@@ -50,7 +50,7 @@ class AirbrakeTarget extends Target
             // add additional information available from logger
             $airbrakeNotice['context']['severity'] = Logger::getLevelName($level);
             $airbrakeNotice['context']['category'] = $category;
-            $airbrakeNotice['context']['timestamp'] = date('Y-m-d H:i:s', $timestamp);
+            $airbrakeNotice['context']['timestamp'] = date('Y-m-d H:i:s', intval($timestamp));
 
             if ($airbrakeNotice !== null) {
                 $this->airbrakeService->sendNotice($airbrakeNotice);

--- a/src/Notifier.php
+++ b/src/Notifier.php
@@ -12,7 +12,7 @@ class Notifier extends AirbrakeNotifier
     /**
      * @var array
      */
-    private $errorConfig;
+    protected $errorConfig;
 
     public function __construct($opt)
     {

--- a/src/Notifier.php
+++ b/src/Notifier.php
@@ -25,7 +25,7 @@ class Notifier extends AirbrakeNotifier
             if (isset($user->id)) {
                 $notice['context']['user']['id'] = $user->id;
             }
-            if (isset($user->identity)) {
+            if (isset($user->identity) && isset($this->user)) {
                 $notice['context']['user'] = $this->user->call($this, $user->identity);
             }
         }

--- a/src/Notifier.php
+++ b/src/Notifier.php
@@ -9,6 +9,11 @@ class Notifier extends AirbrakeNotifier
 {
     private $user;
 
+    /**
+     * @var array
+     */
+    private $errorConfig;
+
     public function __construct($opt)
     {
         parent::__construct($opt);


### PR DESCRIPTION
- The `airbrake/phpbrake` package is maintained at version 8.0 to ensure compatibility with PHP 7 and 8.
- The bug `Call to a member function call() on null` has been fixed. This error occurred when the user context introduced in #3 was not configured.
- Deprecated warnings for PHP 8.2 have been suppressed.